### PR TITLE
Use correct name for `PsrLoggerAbstractAdapterFactory` in documentation

### DIFF
--- a/docs/book/service-manager.md
+++ b/docs/book/service-manager.md
@@ -110,22 +110,22 @@ Because the main filter is `Priority`, it can be set directly too:
 ];
 ```
 
-## PsrLoggerAbstractServiceFactory
+## PsrLoggerAbstractAdapterFactory
 
 As with the [`LoggerAbstractServiceFactory` above](#loggerabstractservicefactory),
-you can use `PsrLoggerAbstractServiceFactory` to create [PSR-3-conforming
+you can use `PsrLoggerAbstractAdapterFactory` to create [PSR-3-conforming
 logger instances](psr3.md). Register it as an abstract factory in your
 configuration; as an example:
 
 ```php
 // module.config.php
 
-use Laminas\Log\PsrLoggerAbstractServiceFactory;
+use Laminas\Log\PsrLoggerAbstractAdapterFactory;
 
 return [
     'service_manager' => [
         'abstract_factories' => [
-            PsrLoggerAbstractServiceFactory::class,
+            PsrLoggerAbstractAdapterFactory::class,
         ],
     ],
 ];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

See https://discourse.laminas.dev/t/creating-a-psr-3-logger-using-the-configuration/1968