### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-servicemanager": "^3.3.0",
         "laminas/laminas-stdlib": "^3.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/log": "^1.1.2"
     },
     "require-dev": {
@@ -77,7 +76,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-log": "^2.12.0"
+    "conflict": {
+        "zendframework/zend-log": "*"
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
