### PR TITLE
Have LoggerServiceFactory inject writer and processor plugin managers

### DIFF
--- a/src/Filter/Validator.php
+++ b/src/Filter/Validator.php
@@ -32,7 +32,7 @@ class Validator implements FilterInterface
      */
     public function __construct($validator)
     {
-        if ($validator instanceof Traversable) {
+        if ($validator instanceof Traversable && ! $validator instanceof LaminasValidator) {
             $validator = iterator_to_array($validator);
         }
         if (is_array($validator)) {

--- a/src/LoggerAbstractServiceFactory.php
+++ b/src/LoggerAbstractServiceFactory.php
@@ -5,33 +5,37 @@ declare(strict_types=1);
 namespace Laminas\Log;
 
 use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\AbstractFactoryInterface;
-use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\ServiceLocatorInterface;
-
-use function is_string;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Logger abstract service factory.
  *
  * Allow to configure multiple loggers for application.
  */
-class LoggerAbstractServiceFactory implements AbstractFactoryInterface
+class LoggerAbstractServiceFactory extends LoggerServiceFactory implements AbstractFactoryInterface
 {
-    /** @var array */
-    protected $config;
+    protected array $config;
 
     /**
      * Configuration key holding logger configuration
-     *
-     * @var string
      */
-    protected $configKey = 'log';
+    protected string $configKey;
+
+    public function __construct(string $configKey = 'log')
+    {
+        $this->configKey = $configKey;
+    }
 
     /**
-     * {@inheritDoc}
+     * @param string $requestedName
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function canCreate(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, $requestedName): bool
     {
         $config = $this->getConfig($container);
         if (empty($config)) {
@@ -42,17 +46,20 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param string $requestedName
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName): bool
     {
-        return $this->canCreate($container, $requestedName);
+        return $this->canCreate($serviceLocator, $requestedName);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Logger
     {
         $config = $this->getConfig($container);
         $config = $config[$requestedName];
@@ -63,21 +70,26 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @param string $name
+     * @param string $requestedName
+     * @throws ContainerException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName): Logger
     {
-        return $this($container, $requestedName);
+        return $this($serviceLocator, $requestedName);
     }
 
     /**
      * Retrieve configuration for loggers, if any
      *
-     * @return array
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    protected function getConfig(ContainerInterface $services)
+    protected function getConfig(ContainerInterface $services): array
     {
-        if ($this->config !== null) {
+        if (isset($this->config)) {
             return $this->config;
         }
 
@@ -97,102 +109,5 @@ class LoggerAbstractServiceFactory implements AbstractFactoryInterface
         $this->config = $config[$this->configKey];
 
         return $this->config;
-    }
-
-    /**
-     * Process and return the configuration from the container.
-     *
-     * @param array $config Passed by reference
-     */
-    protected function processConfig(&$config, ContainerInterface $services)
-    {
-        if (
-            isset($config['writer_plugin_manager'])
-            && is_string($config['writer_plugin_manager'])
-            && $services->has($config['writer_plugin_manager'])
-        ) {
-            $config['writer_plugin_manager'] = $services->get($config['writer_plugin_manager']);
-        }
-
-        if (
-            (! isset($config['writer_plugin_manager'])
-                || ! $config['writer_plugin_manager'] instanceof AbstractPluginManager)
-            && $services->has('LogWriterManager')
-        ) {
-            $config['writer_plugin_manager'] = $services->get('LogWriterManager');
-        }
-
-        if (
-            isset($config['processor_plugin_manager'])
-            && is_string($config['processor_plugin_manager'])
-            && $services->has($config['processor_plugin_manager'])
-        ) {
-            $config['processor_plugin_manager'] = $services->get($config['processor_plugin_manager']);
-        }
-
-        if (
-            (! isset($config['processor_plugin_manager'])
-                || ! $config['processor_plugin_manager'] instanceof AbstractPluginManager)
-            && $services->has('LogProcessorManager')
-        ) {
-            $config['processor_plugin_manager'] = $services->get('LogProcessorManager');
-        }
-
-        if (! isset($config['writers'])) {
-            return;
-        }
-
-        foreach ($config['writers'] as $index => $writerConfig) {
-            if (
-                isset($writerConfig['name'])
-                && ('db' === $writerConfig['name']
-                    || Writer\Db::class === $writerConfig['name']
-                    || 'laminaslogwriterdb' === $writerConfig['name']
-                )
-                && isset($writerConfig['options']['db'])
-                && is_string($writerConfig['options']['db'])
-                && $services->has($writerConfig['options']['db'])
-            ) {
-                // Retrieve the DB service from the service locator, and
-                // inject it into the configuration.
-                $db                                         = $services->get($writerConfig['options']['db']);
-                $config['writers'][$index]['options']['db'] = $db;
-                continue;
-            }
-
-            if (
-                isset($writerConfig['name'])
-                && ('mongo' === $writerConfig['name']
-                    || Writer\Mongo::class === $writerConfig['name']
-                    || 'laminaslogwritermongo' === $writerConfig['name']
-                )
-                && isset($writerConfig['options']['mongo'])
-                && is_string($writerConfig['options']['mongo'])
-                && $services->has($writerConfig['options']['mongo'])
-            ) {
-                // Retrieve the Mongo service from the service locator, and
-                // inject it into the configuration.
-                $mongoClient                                   = $services->get($writerConfig['options']['mongo']);
-                $config['writers'][$index]['options']['mongo'] = $mongoClient;
-                continue;
-            }
-
-            if (
-                isset($writerConfig['name'])
-                && ('mongodb' === $writerConfig['name']
-                    || Writer\MongoDB::class === $writerConfig['name']
-                    || 'laminaslogwritermongodb' === $writerConfig['name']
-                )
-                && isset($writerConfig['options']['manager'])
-                && is_string($writerConfig['options']['manager'])
-                && $services->has($writerConfig['options']['manager'])
-            ) {
-                // Retrieve the MongoDB Manager service from the service locator, and
-                // inject it into the configuration.
-                $manager                                         = $services->get($writerConfig['options']['manager']);
-                $config['writers'][$index]['options']['manager'] = $manager;
-                continue;
-            }
-        }
     }
 }

--- a/src/LoggerAbstractServiceFactory.php
+++ b/src/LoggerAbstractServiceFactory.php
@@ -18,12 +18,12 @@ use Psr\Container\NotFoundExceptionInterface;
  */
 class LoggerAbstractServiceFactory extends LoggerServiceFactory implements AbstractFactoryInterface
 {
-    protected array $config;
+    protected $config;
 
     /**
      * Configuration key holding logger configuration
      */
-    protected string $configKey;
+    protected $configKey;
 
     public function __construct(string $configKey = 'log')
     {
@@ -32,10 +32,11 @@ class LoggerAbstractServiceFactory extends LoggerServiceFactory implements Abstr
 
     /**
      * @param string $requestedName
+     * @return bool
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function canCreate(ContainerInterface $container, $requestedName): bool
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
         $config = $this->getConfig($container);
         if (empty($config)) {
@@ -48,10 +49,11 @@ class LoggerAbstractServiceFactory extends LoggerServiceFactory implements Abstr
     /**
      * @param string $name
      * @param string $requestedName
+     * @return bool
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName): bool
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         return $this->canCreate($serviceLocator, $requestedName);
     }
@@ -59,7 +61,7 @@ class LoggerAbstractServiceFactory extends LoggerServiceFactory implements Abstr
     /**
      * {@inheritdoc}
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Logger
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $config = $this->getConfig($container);
         $config = $config[$requestedName];
@@ -72,11 +74,12 @@ class LoggerAbstractServiceFactory extends LoggerServiceFactory implements Abstr
     /**
      * @param string $name
      * @param string $requestedName
+     * @return Logger
      * @throws ContainerException
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName): Logger
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         return $this($serviceLocator, $requestedName);
     }

--- a/src/LoggerAbstractServiceFactory.php
+++ b/src/LoggerAbstractServiceFactory.php
@@ -18,10 +18,13 @@ use Psr\Container\NotFoundExceptionInterface;
  */
 class LoggerAbstractServiceFactory extends LoggerServiceFactory implements AbstractFactoryInterface
 {
+    /** @var array */
     protected $config;
 
     /**
      * Configuration key holding logger configuration
+     *
+     * @var string
      */
     protected $configKey;
 
@@ -87,10 +90,11 @@ class LoggerAbstractServiceFactory extends LoggerServiceFactory implements Abstr
     /**
      * Retrieve configuration for loggers, if any
      *
+     * @return array
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    protected function getConfig(ContainerInterface $services): array
+    protected function getConfig(ContainerInterface $services)
     {
         if (isset($this->config)) {
             return $this->config;

--- a/src/LoggerServiceFactory.php
+++ b/src/LoggerServiceFactory.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Laminas\Log;
 
 use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+use function is_string;
 
 /**
  * Factory for logger instances.
@@ -16,15 +21,19 @@ class LoggerServiceFactory implements FactoryInterface
     /**
      * Factory for laminas-servicemanager v3.
      *
-     * @param string $name
+     * @param string $requestedName
      * @param null|array $options
-     * @return Logger
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Logger
     {
         // Configure the logger
         $config    = $container->get('config');
         $logConfig = $config['log'] ?? [];
+
+        $this->processConfig($logConfig, $container);
+
         return new Logger($logConfig);
     }
 
@@ -33,10 +42,108 @@ class LoggerServiceFactory implements FactoryInterface
      *
      * Proxies to `__invoke()`.
      *
-     * @return Logger
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function createService(ServiceLocatorInterface $serviceLocator): Logger
     {
         return $this($serviceLocator, Logger::class);
+    }
+
+    /**
+     * Process and return the configuration from the container.
+     *
+     * @param array $config Passed by reference
+     */
+    protected function processConfig(&$config, ContainerInterface $services)
+    {
+        if (
+            isset($config['writer_plugin_manager'])
+            && is_string($config['writer_plugin_manager'])
+            && $services->has($config['writer_plugin_manager'])
+        ) {
+            $config['writer_plugin_manager'] = $services->get($config['writer_plugin_manager']);
+        }
+
+        if (
+            (! isset($config['writer_plugin_manager'])
+                || ! $config['writer_plugin_manager'] instanceof AbstractPluginManager)
+            && $services->has('LogWriterManager')
+        ) {
+            $config['writer_plugin_manager'] = $services->get('LogWriterManager');
+        }
+
+        if (
+            isset($config['processor_plugin_manager'])
+            && is_string($config['processor_plugin_manager'])
+            && $services->has($config['processor_plugin_manager'])
+        ) {
+            $config['processor_plugin_manager'] = $services->get($config['processor_plugin_manager']);
+        }
+
+        if (
+            (! isset($config['processor_plugin_manager'])
+                || ! $config['processor_plugin_manager'] instanceof AbstractPluginManager)
+            && $services->has('LogProcessorManager')
+        ) {
+            $config['processor_plugin_manager'] = $services->get('LogProcessorManager');
+        }
+
+        if (! isset($config['writers'])) {
+            return;
+        }
+
+        foreach ($config['writers'] as $index => $writerConfig) {
+            if (
+                isset($writerConfig['name'])
+                && ('db' === $writerConfig['name']
+                    || Writer\Db::class === $writerConfig['name']
+                    || 'laminaslogwriterdb' === $writerConfig['name']
+                )
+                && isset($writerConfig['options']['db'])
+                && is_string($writerConfig['options']['db'])
+                && $services->has($writerConfig['options']['db'])
+            ) {
+                // Retrieve the DB service from the service locator, and
+                // inject it into the configuration.
+                $db                                         = $services->get($writerConfig['options']['db']);
+                $config['writers'][$index]['options']['db'] = $db;
+                continue;
+            }
+
+            if (
+                isset($writerConfig['name'])
+                && ('mongo' === $writerConfig['name']
+                    || Writer\Mongo::class === $writerConfig['name']
+                    || 'laminaslogwritermongo' === $writerConfig['name']
+                )
+                && isset($writerConfig['options']['mongo'])
+                && is_string($writerConfig['options']['mongo'])
+                && $services->has($writerConfig['options']['mongo'])
+            ) {
+                // Retrieve the Mongo service from the service locator, and
+                // inject it into the configuration.
+                $mongoClient                                   = $services->get($writerConfig['options']['mongo']);
+                $config['writers'][$index]['options']['mongo'] = $mongoClient;
+                continue;
+            }
+
+            if (
+                isset($writerConfig['name'])
+                && ('mongodb' === $writerConfig['name']
+                    || Writer\MongoDB::class === $writerConfig['name']
+                    || 'laminaslogwritermongodb' === $writerConfig['name']
+                )
+                && isset($writerConfig['options']['manager'])
+                && is_string($writerConfig['options']['manager'])
+                && $services->has($writerConfig['options']['manager'])
+            ) {
+                // Retrieve the MongoDB Manager service from the service locator, and
+                // inject it into the configuration.
+                $manager                                         = $services->get($writerConfig['options']['manager']);
+                $config['writers'][$index]['options']['manager'] = $manager;
+                continue;
+            }
+        }
     }
 }

--- a/src/LoggerServiceFactory.php
+++ b/src/LoggerServiceFactory.php
@@ -23,10 +23,11 @@ class LoggerServiceFactory implements FactoryInterface
      *
      * @param string $requestedName
      * @param null|array $options
+     * @return Logger
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Logger
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         // Configure the logger
         $config    = $container->get('config');
@@ -42,10 +43,11 @@ class LoggerServiceFactory implements FactoryInterface
      *
      * Proxies to `__invoke()`.
      *
+     * @return Logger
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function createService(ServiceLocatorInterface $serviceLocator): Logger
+    public function createService(ServiceLocatorInterface $serviceLocator)
     {
         return $this($serviceLocator, Logger::class);
     }
@@ -53,9 +55,10 @@ class LoggerServiceFactory implements FactoryInterface
     /**
      * Process and return the configuration from the container.
      *
-     * @param array $config Passed by reference
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    protected function processConfig(&$config, ContainerInterface $services)
+    protected function processConfig(array &$config, ContainerInterface $services)
     {
         if (
             isset($config['writer_plugin_manager'])
@@ -142,7 +145,6 @@ class LoggerServiceFactory implements FactoryInterface
                 // inject it into the configuration.
                 $manager                                         = $services->get($writerConfig['options']['manager']);
                 $config['writers'][$index]['options']['manager'] = $manager;
-                continue;
             }
         }
     }

--- a/src/PsrLoggerAbstractAdapterFactory.php
+++ b/src/PsrLoggerAbstractAdapterFactory.php
@@ -5,25 +5,80 @@ declare(strict_types=1);
 namespace Laminas\Log;
 
 use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Laminas\ServiceManager\AbstractFactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * PSR Logger abstract service factory.
  *
  * Allow to configure multiple loggers for application.
  */
-class PsrLoggerAbstractAdapterFactory extends LoggerAbstractServiceFactory
+class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
 {
     /**
      * Configuration key holding logger configuration
-     *
-     * @var string
      */
-    protected $configKey = 'psr_log';
+    protected string $configKey = 'psr_log';
 
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    private LoggerAbstractServiceFactory $loggerAbstractServiceFactory;
+
+    public function __construct()
     {
-        $logger = parent::__invoke($container, $requestedName, $options);
+        $this->loggerAbstractServiceFactory = new LoggerAbstractServiceFactory($this->configKey);
+    }
+
+    /**
+     * @param string $requestedName
+     * @throws ContainerException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): PsrLoggerAdapter
+    {
+        $loggerFactory = $this->loggerAbstractServiceFactory;
+        $logger        = $loggerFactory($container, $requestedName);
 
         return new PsrLoggerAdapter($logger);
+    }
+
+    /**
+     * Determine if we can create a service with name
+     *
+     * @param string $name
+     * @param string $requestedName
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName): bool
+    {
+        return $this->loggerAbstractServiceFactory->canCreate($serviceLocator, $name);
+    }
+
+    /**
+     * Can the factory create an instance for the service?
+     *
+     * @param string $requestedName
+     */
+    public function canCreate(ContainerInterface $container, $requestedName): bool
+    {
+        return $this->loggerAbstractServiceFactory->canCreate($container, $requestedName);
+    }
+
+    /**
+     * Create service with name
+     *
+     * @param string $name
+     * @param string $requestedName
+     * @throws ContainerException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function createServiceWithName(
+        ServiceLocatorInterface $serviceLocator,
+        $name,
+        $requestedName
+    ): PsrLoggerAdapter {
+        return $this($serviceLocator, $requestedName);
     }
 }

--- a/src/PsrLoggerAbstractAdapterFactory.php
+++ b/src/PsrLoggerAbstractAdapterFactory.php
@@ -20,6 +20,8 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
 {
     /**
      * Configuration key holding logger configuration
+     *
+     * @var string
      */
     protected $configKey = 'psr_log';
 
@@ -56,7 +58,7 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
      */
     public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
-        return $this->loggerAbstractServiceFactory->canCreate($serviceLocator, $name);
+        return $this->canCreate($serviceLocator, $name);
     }
 
     /**

--- a/src/PsrLoggerAbstractAdapterFactory.php
+++ b/src/PsrLoggerAbstractAdapterFactory.php
@@ -21,7 +21,7 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
     /**
      * Configuration key holding logger configuration
      */
-    protected string $configKey = 'psr_log';
+    protected $configKey = 'psr_log';
 
     private LoggerAbstractServiceFactory $loggerAbstractServiceFactory;
 
@@ -32,11 +32,12 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
 
     /**
      * @param string $requestedName
+     * @return PsrLoggerAdapter
      * @throws ContainerException
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): PsrLoggerAdapter
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $loggerFactory = $this->loggerAbstractServiceFactory;
         $logger        = $loggerFactory($container, $requestedName);
@@ -49,8 +50,11 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
      *
      * @param string $name
      * @param string $requestedName
+     * @return bool
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName): bool
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
     {
         return $this->loggerAbstractServiceFactory->canCreate($serviceLocator, $name);
     }
@@ -59,8 +63,11 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
      * Can the factory create an instance for the service?
      *
      * @param string $requestedName
+     * @return bool
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
-    public function canCreate(ContainerInterface $container, $requestedName): bool
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
         return $this->loggerAbstractServiceFactory->canCreate($container, $requestedName);
     }
@@ -70,15 +77,13 @@ class PsrLoggerAbstractAdapterFactory implements AbstractFactoryInterface
      *
      * @param string $name
      * @param string $requestedName
+     * @return PsrLoggerAdapter
      * @throws ContainerException
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
-    public function createServiceWithName(
-        ServiceLocatorInterface $serviceLocator,
-        $name,
-        $requestedName
-    ): PsrLoggerAdapter {
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
         return $this($serviceLocator, $requestedName);
     }
 }

--- a/test/Filter/ValidatorTest.php
+++ b/test/Filter/ValidatorTest.php
@@ -15,10 +15,10 @@ class ValidatorTest extends TestCase
     public function testValidatorFilter(): void
     {
         $filter = new Validator(new DigitsFilter());
-        $this->assertTrue($filter->filter(['message' => '123']));
-        $this->assertFalse($filter->filter(['message' => 'test']));
-        $this->assertFalse($filter->filter(['message' => 'test123']));
-        $this->assertFalse($filter->filter(['message' => '(%$']));
+        self::assertTrue($filter->filter(['message' => '123']));
+        self::assertFalse($filter->filter(['message' => 'test']));
+        self::assertFalse($filter->filter(['message' => 'test123']));
+        self::assertFalse($filter->filter(['message' => '(%$']));
     }
 
     public function testValidatorChain(): void
@@ -27,7 +27,7 @@ class ValidatorTest extends TestCase
         $validatorChain->attach(new NotEmptyFilter());
         $validatorChain->attach(new DigitsFilter());
         $filter = new Validator($validatorChain);
-        $this->assertTrue($filter->filter(['message' => '123']));
-        $this->assertFalse($filter->filter(['message' => 'test']));
+        self::assertTrue($filter->filter(['message' => '123']));
+        self::assertFalse($filter->filter(['message' => 'test']));
     }
 }

--- a/test/LoggerServiceFactoryTest.php
+++ b/test/LoggerServiceFactoryTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Log;
+
+use Closure;
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Log\Logger;
+use Laminas\Log\LoggerServiceFactory;
+use Laminas\Log\Processor\ProcessorInterface;
+use Laminas\Log\ProcessorPluginManager;
+use Laminas\Log\Writer\Db as DbWriter;
+use Laminas\Log\Writer\MongoDB as MongoDBWriter;
+use Laminas\Log\Writer\Noop;
+use Laminas\Log\Writer\WriterInterface;
+use Laminas\Log\WriterPluginManager;
+use Laminas\ServiceManager\Config;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceManager;
+use MongoDB\Driver\Manager;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+use function count;
+use function extension_loaded;
+
+class LoggerServiceFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    protected ServiceLocatorInterface $serviceManager;
+
+    /**
+     * Set up LoggerServiceFactory and loggers configuration.
+     */
+    protected function setUp(): void
+    {
+        $this->serviceManager = new ServiceManager();
+        $config               = new Config([
+            'aliases'   => [
+                'Laminas\Log' => Logger::class,
+            ],
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'config' => [
+                    'log' => [],
+                ],
+            ],
+        ]);
+        $config->configureServiceManager($this->serviceManager);
+    }
+
+    public function providerValidLoggerService(): array
+    {
+        return [
+            [Logger::class],
+            ['Laminas\Log'],
+        ];
+    }
+
+    public function providerInvalidLoggerService(): array
+    {
+        return [
+            ['log'],
+            ['Logger\Application\Frontend'],
+            ['writers'],
+        ];
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @dataProvider providerValidLoggerService
+     */
+    public function testValidLoggerService(string $service): void
+    {
+        $actual = $this->serviceManager->get($service);
+        self::assertInstanceOf(Logger::class, $actual);
+    }
+
+    /**
+     * @dataProvider providerInvalidLoggerService
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testInvalidLoggerService(string $service): void
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->serviceManager->get($service);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testRetrievesDatabaseServiceWhenUsingDbWriter(): void
+    {
+        $db = $this->getMockBuilder(Adapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config         = new Config([
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'Db\Logger' => $db,
+                'config'    => [
+                    'log' => [
+                        'writers' => [
+                            [
+                                'name'     => 'db',
+                                'priority' => 1,
+                                'options'  => [
+                                    'separator' => '_',
+                                    'column'    => [],
+                                    'table'     => 'applicationlog',
+                                    'db'        => 'Db\Logger',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $serviceManager = new ServiceManager();
+        $config->configureServiceManager($serviceManager);
+
+        $logger = $serviceManager->get(Logger::class);
+        self::assertInstanceOf(Logger::class, $logger);
+        $writers = $logger->getWriters();
+        $found   = false;
+
+        $writer = null;
+        foreach ($writers as $writer) {
+            if ($writer instanceof DbWriter) {
+                $found = true;
+                break;
+            }
+        }
+
+        self::assertTrue($found, 'Did not find expected DB writer');
+
+        $writerDb = Closure::bind(function () {
+            return $this->db;
+        }, $writer, DbWriter::class)();
+
+        self::assertSame($db, $writerDb);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testRetrievesMongoDBServiceWhenUsingMongoDbWriter(): void
+    {
+        if (! extension_loaded('mongodb')) {
+            self::markTestSkipped('The mongodb PHP extension is not available');
+        }
+
+        $manager = new Manager('mongodb://localhost:27017');
+
+        $config         = new Config([
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'mongo_manager' => $manager,
+                'config'        => [
+                    'log' => [
+                        'writers' => [
+                            [
+                                'name'     => 'mongodb',
+                                'priority' => 1,
+                                'options'  => [
+                                    'database'   => 'applicationdb',
+                                    'collection' => 'applicationlog',
+                                    'manager'    => 'mongo_manager',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $serviceManager = new ServiceManager();
+        $config->configureServiceManager($serviceManager);
+
+        $logger = $serviceManager->get(Logger::class);
+        self::assertInstanceOf(Logger::class, $logger);
+
+        $found = false;
+        foreach ($logger->getWriters() as $writer) {
+            if ($writer instanceof MongoDBWriter) {
+                $found = true;
+                break;
+            }
+        }
+
+        self::assertTrue($found, 'Did not find expected mongo db writer');
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testWillInjectWriterPluginManagerIfAvailable(): void
+    {
+        $writers    = new WriterPluginManager(new ServiceManager());
+        $mockWriter = $this->createMock(WriterInterface::class);
+        $writers->setService('CustomWriter', $mockWriter);
+
+        $config   = new Config([
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'LogWriterManager' => $writers,
+                'config'           => [
+                    'log' => [
+                        'writers' => [['name' => 'CustomWriter']],
+                    ],
+                ],
+            ],
+        ]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
+
+        $log        = $services->get(Logger::class);
+        $logWriters = $log->getWriters();
+        self::assertEquals(1, count($logWriters));
+        $writer = $logWriters->current();
+        self::assertSame($mockWriter, $writer);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testWillInjectProcessorPluginManagerIfAvailable(): void
+    {
+        $processors    = new ProcessorPluginManager(new ServiceManager());
+        $mockProcessor = $this->createMock(ProcessorInterface::class);
+        $processors->setService('CustomProcessor', $mockProcessor);
+
+        $config   = new Config([
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'LogProcessorManager' => $processors,
+                'config'              => [
+                    'log' => [
+                        'writers'    => [['name' => Noop::class]],
+                        'processors' => [['name' => 'CustomProcessor']],
+                    ],
+                ],
+            ],
+        ]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
+
+        $log           = $services->get(Logger::class);
+        $logProcessors = $log->getProcessors();
+        self::assertEquals(1, count($logProcessors));
+        $processor = $logProcessors->current();
+        self::assertSame($mockProcessor, $processor);
+    }
+}

--- a/test/LoggerServiceFactoryTest.php
+++ b/test/LoggerServiceFactoryTest.php
@@ -21,7 +21,6 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
 use MongoDB\Driver\Manager;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -30,8 +29,6 @@ use function extension_loaded;
 
 class LoggerServiceFactoryTest extends TestCase
 {
-    use ProphecyTrait;
-
     protected ServiceLocatorInterface $serviceManager;
 
     /**

--- a/test/LoggerServiceFactoryTest.php
+++ b/test/LoggerServiceFactoryTest.php
@@ -16,13 +16,16 @@ use Laminas\Log\Writer\Noop;
 use Laminas\Log\Writer\WriterInterface;
 use Laminas\Log\WriterPluginManager;
 use Laminas\ServiceManager\Config;
+use Laminas\ServiceManager\Exception\InvalidArgumentException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Stdlib\ArrayObject;
 use MongoDB\Driver\Manager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use stdClass;
 
 use function count;
 use function extension_loaded;
@@ -268,5 +271,84 @@ class LoggerServiceFactoryTest extends TestCase
         self::assertEquals(1, count($logProcessors));
         $processor = $logProcessors->current();
         self::assertSame($mockProcessor, $processor);
+    }
+
+    /**
+     * @dataProvider dataWritersValues()
+     * @param int|string|object $writers
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testWritersValue($writers, $count): void
+    {
+        $config   = new Config([
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'config' => [
+                    'log' => [
+                        'writers' => $writers,
+                    ],
+                ],
+            ],
+        ]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
+
+        /** @var Logger $log */
+        $log = $services->get(Logger::class);
+        self::assertCount($count, $log->getWriters());
+    }
+
+    public function dataWritersValues(): array
+    {
+        return [
+            'null'           => [null, 0],
+            'string'         => ['writers config', 0],
+            'number'         => [1e3, 0],
+            'object'         => [new stdClass(), 0],
+            'empty iterable' => [new ArrayObject(), 0],
+            'iterable'       => [new ArrayObject([['name' => Noop::class]]), 1],
+        ];
+    }
+
+    /**
+     * @dataProvider dataInvalidWriterConfig()
+     * @param string|object $value
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function testInvalidWriterConfig($value, string $type): void
+    {
+        $config   = new Config([
+            'factories' => [
+                Logger::class => LoggerServiceFactory::class,
+            ],
+            'services'  => [
+                'config' => [
+                    'log' => [
+                        'writers' => [
+                            $value,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('config log.writers[] must contain array or ArrayAccess, ' . $type . ' provided');
+
+        $services->get(Logger::class);
+    }
+
+    public function dataInvalidWriterConfig(): array
+    {
+        return [
+            'string' => ['invalid config', 'string'],
+            'object' => [new stdClass(), 'stdClass'],
+        ];
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no

### Description

The issue: `LoggerServiceFactory` does not inject the writer nor the processor plugin managers. But `LoggerAbstractServiceFactory` does. And I want to use the former with custom processors.

I changed the inheritance so `LoggerAbstractServiceFactory` extends `LoggerServiceFactory` and moved some logic, so both inject the relevant plugin managers in the same way.

I changed `PsrLoggerAbstractAdapterFactory` to compose  `LoggerAbstractServiceFactory`, not inherit. It didn't make sense as the return types for `__invoke` were incompatible. So adding strict typing across much of the factories would be possible now

Added unit tests for `LoggerServiceFactory`. All other unit tests still pass, and the factories can still be used in exactly the same way. Only difference is now `LoggerServiceFactory` injects the plugin managers.

Typing only added to anything new to maintain BC

I want to target the 2.15.x branch, as i see this as a bugfix - however, i am new to open source, and am open to guidance.